### PR TITLE
Changed tensorflow-gpu==1.15.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-tensorflow-gpu==1.15.2
+tensorflow-gpu==1.15.0
 pandas==1.1.4
 nltk==3.5


### PR DESCRIPTION
Changed tensorflow-gpu==1.15.2 to tensorflow-gpu==1.15.0  due to error- ERROR: No matching distribution found for tensorflow-gpu==1.15.2 (from -r requirements.txt (line 1))